### PR TITLE
feat(eks-mcp-server): Add MCP tool to retrieve EKS cluster names

### DIFF
--- a/src/eks-mcp-server/README.md
+++ b/src/eks-mcp-server/README.md
@@ -35,6 +35,7 @@ For read operations, the following permissions are required:
       "Effect": "Allow",
       "Action": [
         "eks:DescribeCluster",
+        "eks:ListClusters",
         "cloudformation:DescribeStacks",
         "cloudwatch:GetMetricData",
         "logs:StartQuery",
@@ -270,6 +271,24 @@ Specifies the AWS region where EKS clusters are managed, which will be used for 
 The following tools are provided by the EKS MCP server for managing Amazon EKS clusters and Kubernetes resources. Each tool performs a specific action that can be invoked to automate common tasks in your EKS clusters and Kubernetes workloads.
 
 ### EKS Cluster Management
+
+#### `list_clusters`
+
+Lists all EKS clusters in the current AWS account and region.
+
+Features:
+
+* Discovers all Amazon EKS clusters in the current AWS account and region.
+* Provides cluster names and total count for cluster inventory.
+* Supports pagination for large numbers of clusters.
+* Can include external/connected clusters when specified.
+* Useful for discovering available clusters before performing operations.
+
+Parameters:
+
+* `max_results` (optional): Maximum number of results to return (1-100)
+* `next_token` (optional): Token for pagination continuation
+* `include` (optional): List containing 'all' to include external clusters
 
 #### `manage_eks_stacks`
 
@@ -521,7 +540,7 @@ When using the EKS MCP Server, consider the following:
 
 The EKS MCP Server can be used for production environments with proper security controls in place. The server runs in read-only mode by default, which is recommended and considered generally safer for production environments. Only explicitly enable write access when necessary. Below are the EKS MCP server tools available in read-only versus write-access mode:
 
-* **Read-only mode (default)**: `manage_eks_stacks` (with operation="describe"), `manage_k8s_resource` (with operation="read"), `list_k8s_resources`, `get_pod_logs`, `get_k8s_events`, `get_cloudwatch_logs`, `get_cloudwatch_metrics`, `get_policies_for_role`, `search_eks_troubleshoot_guide`, `list_api_versions`.
+* **Read-only mode (default)**: `list_clusters`, `manage_eks_stacks` (with operation="describe"), `manage_k8s_resource` (with operation="read"), `list_k8s_resources`, `get_pod_logs`, `get_k8s_events`, `get_cloudwatch_logs`, `get_cloudwatch_metrics`, `get_policies_for_role`, `search_eks_troubleshoot_guide`, `list_api_versions`.
 * **Write-access mode**: (require `--allow-write`): `manage_eks_stacks` (with "generate", "deploy", "delete"), `manage_k8s_resource` (with "create", "replace", "patch", "delete"), `apply_yaml`, `generate_app_manifest`, `add_inline_policy`.
 
 #### `autoApprove` (optional)
@@ -543,6 +562,7 @@ An array within the MCP server definition that lists tool names to be automatica
         "FASTMCP_LOG_LEVEL": "INFO"
       },
       "autoApprove": [
+        "list_clusters",
         "manage_eks_stacks",
         "manage_k8s_resource",
         "list_k8s_resources",
@@ -576,6 +596,7 @@ An array within the MCP server definition that lists tool names to be automatica
         "FASTMCP_LOG_LEVEL": "INFO"
       },
       "autoApprove": [
+        "list_clusters",
         "manage_eks_stacks",
         "manage_k8s_resource",
         "list_k8s_resources",

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/eks_cluster_handler.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/eks_cluster_handler.py
@@ -1,0 +1,107 @@
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.logging_helper import LogLevel, log_with_request_id
+from awslabs.eks_mcp_server.models import ListClustersResponse
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from typing import List, Optional
+
+
+class EksClusterHandler:
+    """Handler for Amazon EKS cluster operations.
+
+    This class provides tools for interacting with Amazon EKS clusters,
+    including listing available clusters.
+    """
+
+    def __init__(self, mcp):
+        """Initialize the EKS cluster handler.
+
+        Args:
+            mcp: The MCP server instance
+        """
+        self.mcp = mcp
+
+        # Register tools
+        self.mcp.tool(name='list_clusters')(self.list_clusters)
+
+    async def list_clusters(
+        self, 
+        ctx: Context,
+        max_results: Optional[int] = None,
+        next_token: Optional[str] = None,
+        include: Optional[List[str]] = None
+    ) -> ListClustersResponse:
+        """List all EKS clusters in the current AWS account and region.
+
+        This tool retrieves a list of all Amazon EKS clusters in the current AWS
+        account and region. It's useful for discovering available clusters before
+        performing operations on them, such as deploying applications or querying
+        Kubernetes resources.
+
+        ## Requirements
+        - Valid AWS credentials configured
+        - EKS permissions to list clusters
+
+        ## Response Information
+        The response includes a list of cluster names and the total count.
+
+        Args:
+            ctx: MCP context
+            max_results: Maximum number of results (1-100)
+            next_token: Token for pagination
+            include: List containing 'all' to include external clusters
+
+        Returns:
+            ListClustersResponse with cluster names and count
+        """
+        try:
+            log_with_request_id(ctx, LogLevel.INFO, 'Listing EKS clusters')
+
+            # Get EKS client and list clusters
+            eks_client = AwsHelper.create_boto3_client('eks')
+            
+            # Build parameters for list_clusters call
+            params = {}
+            if max_results is not None:
+                params['maxResults'] = max_results
+            if next_token is not None:
+                params['nextToken'] = next_token
+            if include is not None:
+                params['include'] = include
+            
+            response = eks_client.list_clusters(**params)
+            cluster_names = response['clusters']
+            response_next_token = response.get('nextToken')
+
+            # Log success
+            log_with_request_id(
+                ctx, LogLevel.INFO, f'Found {len(cluster_names)} EKS clusters'
+            )
+
+            # Return success response
+            return ListClustersResponse(
+                isError=False,
+                content=[
+                    TextContent(
+                        type='text',
+                        text=f'Successfully listed {len(cluster_names)} EKS clusters',
+                    )
+                ],
+                clusters=cluster_names,
+                count=len(cluster_names),
+                next_token=response_next_token,
+            )
+
+        except Exception as e:
+            # Log error
+            error_msg = f'Failed to list EKS clusters: {str(e)}'
+            log_with_request_id(ctx, LogLevel.ERROR, error_msg)
+
+            # Return error response
+            return ListClustersResponse(
+                isError=True,
+                content=[TextContent(type='text', text=error_msg)],
+                clusters=[],
+                count=0,
+                next_token=None,
+            )

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/models.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/models.py
@@ -283,3 +283,15 @@ class MetricsGuidanceResponse(CallToolResult):
         ..., description='Resource type (cluster, node, pod, namespace, service)'
     )
     metrics: List[Dict[str, Any]] = Field(..., description='List of metrics with their details')
+
+
+class ListClustersResponse(CallToolResult):
+    """Response model for list_clusters tool.
+
+    This model contains the response from listing EKS clusters,
+    including the list of cluster names and count.
+    """
+
+    clusters: List[str] = Field(..., description='List of EKS cluster names')
+    count: int = Field(..., description='Number of clusters found', ge=0)
+    next_token: Optional[str] = Field(None, description='Token for paginated results')

--- a/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
+++ b/src/eks-mcp-server/awslabs/eks_mcp_server/server.py
@@ -26,6 +26,7 @@ Environment Variables:
 import argparse
 from awslabs.eks_mcp_server.cloudwatch_handler import CloudWatchHandler
 from awslabs.eks_mcp_server.cloudwatch_metrics_guidance_handler import CloudWatchMetricsHandler
+from awslabs.eks_mcp_server.eks_cluster_handler import EksClusterHandler
 from awslabs.eks_mcp_server.eks_kb_handler import EKSKnowledgeBaseHandler
 from awslabs.eks_mcp_server.eks_stack_handler import EksStackHandler
 from awslabs.eks_mcp_server.iam_handler import IAMHandler
@@ -62,11 +63,12 @@ DO NOT use standard EKS and Kubernetes CLI commands (aws eks, eksctl, kubectl). 
 5. Monitor the application: `get_pod_logs(cluster_name='my-cluster', namespace='default', pod_name='my-app-pod')`
 
 ### Troubleshooting Application Issues
-1. Check pod status: `list_k8s_resources(cluster_name='my-cluster', kind='Pod', api_version='v1', namespace='default', field_selector='metadata.name=my-pod')`
-2. Get pod events: `get_k8s_events(cluster_name='my-cluster', kind='Pod', name='my-pod', namespace='default')`
-3. Check pod logs: `get_pod_logs(cluster_name='my-cluster', namespace='default', pod_name='my-pod')`
-4. Monitor metrics: `get_cloudwatch_metrics(cluster_name='my-cluster', metric_name='cpu_usage_total', namespace='ContainerInsights', dimensions={'ClusterName': 'my-cluster', 'PodName': 'my-pod', 'Namespace': 'default'})`
-5. Search troubleshooting guide: `search_eks_troubleshoot_guide(query='pod pending')`
+1. List available clusters: `list_clusters(optional: max_results=1-100 for pagination, next_token='token' for continuation, include=['all'] for external clusters)`
+2. Check pod status: `list_k8s_resources(cluster_name='my-cluster', kind='Pod', api_version='v1', namespace='default', field_selector='metadata.name=my-pod')`
+3. Get pod events: `get_k8s_events(cluster_name='my-cluster', kind='Pod', name='my-pod', namespace='default')`
+4. Check pod logs: `get_pod_logs(cluster_name='my-cluster', namespace='default', pod_name='my-pod')`
+5. Monitor metrics: `get_cloudwatch_metrics(cluster_name='my-cluster', metric_name='cpu_usage_total', namespace='ContainerInsights', dimensions={'ClusterName': 'my-cluster', 'PodName': 'my-pod', 'Namespace': 'default'})`
+6. Search troubleshooting guide: `search_eks_troubleshoot_guide(query='pod pending')`
 
 ## Best Practices
 
@@ -145,6 +147,7 @@ def main():
     # Initialize handlers - all tools are always registered, access control is handled within tools
     CloudWatchHandler(mcp, allow_sensitive_data_access)
     EKSKnowledgeBaseHandler(mcp)
+    EksClusterHandler(mcp)
     EksStackHandler(mcp, allow_write)
     K8sHandler(mcp, allow_write, allow_sensitive_data_access)
     IAMHandler(mcp, allow_write)

--- a/src/eks-mcp-server/tests/test_eks_cluster_handler.py
+++ b/src/eks-mcp-server/tests/test_eks_cluster_handler.py
@@ -1,0 +1,131 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for the EKS Cluster Handler."""
+
+import pytest
+from awslabs.eks_mcp_server.aws_helper import AwsHelper
+from awslabs.eks_mcp_server.eks_cluster_handler import EksClusterHandler
+from awslabs.eks_mcp_server.models import ListClustersResponse
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from unittest.mock import MagicMock, patch
+
+
+class TestEksClusterHandler:
+    """Tests for the EksClusterHandler class."""
+
+    def test_init(self):
+        """Test that the handler is initialized correctly and registers its tools."""
+        # Create a mock MCP server
+        mock_mcp = MagicMock()
+
+        # Initialize the EKS cluster handler with the mock MCP server
+        handler = EksClusterHandler(mock_mcp)
+
+        # Verify that the handler has the correct attributes
+        assert handler.mcp == mock_mcp
+
+        # Verify that tools are registered
+        mock_mcp.tool.assert_called_once_with(name='list_clusters')
+
+    @pytest.mark.asyncio
+    @patch.object(AwsHelper, 'create_boto3_client')
+    async def test_list_clusters_success(self, mock_create_client):
+        """Test successful listing of EKS clusters."""
+        # Mock the EKS client
+        mock_eks_client = MagicMock()
+        mock_eks_client.list_clusters.return_value = {
+            'clusters': ['cluster1', 'cluster2', 'cluster3']
+        }
+        mock_create_client.return_value = mock_eks_client
+
+        # Create a mock MCP server and handler
+        mock_mcp = MagicMock()
+        handler = EksClusterHandler(mock_mcp)
+
+        # Create a mock context
+        mock_ctx = MagicMock(spec=Context)
+
+        # Call list_clusters
+        response = await handler.list_clusters(mock_ctx)
+
+        # Verify the response
+        assert isinstance(response, ListClustersResponse)
+        assert response.isError is False
+        assert response.clusters == ['cluster1', 'cluster2', 'cluster3']
+        assert response.count == 3
+        assert len(response.content) == 1
+        assert isinstance(response.content[0], TextContent)
+        assert 'Successfully listed 3 EKS clusters' in response.content[0].text
+
+        # Verify that the EKS client was called correctly
+        mock_create_client.assert_called_once_with('eks')
+        mock_eks_client.list_clusters.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(AwsHelper, 'create_boto3_client')
+    async def test_list_clusters_empty(self, mock_create_client):
+        """Test listing EKS clusters when no clusters exist."""
+        # Mock the EKS client
+        mock_eks_client = MagicMock()
+        mock_eks_client.list_clusters.return_value = {'clusters': []}
+        mock_create_client.return_value = mock_eks_client
+
+        # Create a mock MCP server and handler
+        mock_mcp = MagicMock()
+        handler = EksClusterHandler(mock_mcp)
+
+        # Create a mock context
+        mock_ctx = MagicMock(spec=Context)
+
+        # Call list_clusters
+        response = await handler.list_clusters(mock_ctx)
+
+        # Verify the response
+        assert isinstance(response, ListClustersResponse)
+        assert response.isError is False
+        assert response.clusters == []
+        assert response.count == 0
+        assert len(response.content) == 1
+        assert isinstance(response.content[0], TextContent)
+        assert 'Successfully listed 0 EKS clusters' in response.content[0].text
+
+    @pytest.mark.asyncio
+    @patch.object(AwsHelper, 'create_boto3_client')
+    async def test_list_clusters_failure(self, mock_create_client):
+        """Test failure when listing EKS clusters."""
+        # Mock the EKS client to raise an exception
+        mock_eks_client = MagicMock()
+        mock_eks_client.list_clusters.side_effect = Exception('AWS API Error')
+        mock_create_client.return_value = mock_eks_client
+
+        # Create a mock MCP server and handler
+        mock_mcp = MagicMock()
+        handler = EksClusterHandler(mock_mcp)
+
+        # Create a mock context
+        mock_ctx = MagicMock(spec=Context)
+
+        # Call list_clusters
+        response = await handler.list_clusters(mock_ctx)
+
+        # Verify the response
+        assert isinstance(response, ListClustersResponse)
+        assert response.isError is True
+        assert response.clusters == []
+        assert response.count == 0
+        assert len(response.content) == 1
+        assert isinstance(response.content[0], TextContent)
+        assert 'Failed to list EKS clusters: AWS API Error' in response.content[0].text


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

A new tool is being added to retrieve a list of EKS cluster names.

### User experience

> Please share what the user experience looks like before and after this change

Users have to provide cluster names to other EKS MCP tools. This new tool provides an easy way to retrieve them.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
