### PR TITLE
fix(docker): Use correct script file name in docker file

### DIFF
--- a/src/eks-mcp-server/Dockerfile.supergateway
+++ b/src/eks-mcp-server/Dockerfile.supergateway
@@ -35,8 +35,8 @@ ENV MCP_ALLOW_SENSITIVE_DATA=false
 EXPOSE 8000
 
 # Copy startup script
-COPY docker-start.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-start.sh
+COPY docker-supergateway-start.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-supergateway-start.sh
 
 # Use supergateway as entrypoint
-ENTRYPOINT ["docker-start.sh"]
+ENTRYPOINT ["docker-supergateway-start.sh"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
